### PR TITLE
Ajuste do progresso macro dos jogadores 

### DIFF
--- a/core/src/br/cefetmg/games/screens/BaseScreen.java
+++ b/core/src/br/cefetmg/games/screens/BaseScreen.java
@@ -47,7 +47,7 @@ public abstract class BaseScreen extends ScreenAdapter {
     public Viewport viewport;
     public Rectangle visibleWorldBounds;
     public final AssetManager assets;
-    private BitmapFont messagesFont;
+    protected BitmapFont messagesFont;
     private float deviceAspectRatioDivergenceFromDesired;
     private boolean wasJustDisposed = false;
     private boolean assetsFinishedLoading = false;

--- a/core/src/br/cefetmg/games/screens/MenuScreen.java
+++ b/core/src/br/cefetmg/games/screens/MenuScreen.java
@@ -231,7 +231,7 @@ public class MenuScreen extends BaseScreen {
             transitionScreen(new PlayingGamesScreen(super.game, this),
                     TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
         } else {
-            transitionScreen(new OverworldScreen(super.game, this),
+            transitionScreen(new OverworldScreen(super.game, this, 0, 3),
                     TransitionScreen.Effect.FADE_IN_OUT, 0.4f);
         }
     }

--- a/core/src/br/cefetmg/games/screens/OverworldScreen.java
+++ b/core/src/br/cefetmg/games/screens/OverworldScreen.java
@@ -51,7 +51,7 @@ public class OverworldScreen extends BaseScreen {
             exit, menu, play, water;
     
     private final InputMultiplexer inputMultiplexer;
-    private BitmapFont messagesFont;
+    private BitmapFont fonteDeTexto;
     private ArrayList<Image> locks;
     private boolean desenhaMeio=true;
     private MyMusic backgroundMusic;
@@ -121,7 +121,7 @@ public class OverworldScreen extends BaseScreen {
         menu = new Image(assets.get("world/menu.png", Texture.class));
         play = new Image(assets.get("world/play.png", Texture.class));
         water = new Image(assets.get("world/water.jpg", Texture.class));
-        messagesFont = super.messagesFont;
+        fonteDeTexto = super.messagesFont;
         
         bool1 = true;
         desenhaMeio = true;
@@ -395,8 +395,8 @@ public class OverworldScreen extends BaseScreen {
             ), .1f, .2f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
             score += (3*lives)/3;
             if (currentStage == 0 && score >= FIRST_STAGE_SCORE) currentStage = 1;
-            String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
-            file.writeString(stage, false);
+            String estagio = (String.valueOf(currentStage)+":"+String.valueOf(score));
+            file.writeString(estagio, false);
         }
         
     }
@@ -419,8 +419,8 @@ public class OverworldScreen extends BaseScreen {
             ), .3f, .4f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
             score += (6*lives)/3;
             if (currentStage == 1 && score >= SECOND_STAGE_SCORE) currentStage = 2;
-            String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
-            file.writeString(stage, false);
+            String estagio = (String.valueOf(currentStage)+":"+String.valueOf(score));
+            file.writeString(estagio, false);
         }
     }
 
@@ -440,8 +440,8 @@ public class OverworldScreen extends BaseScreen {
             ), .5f, .6f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
             score += (9*lives)/3;
             if (currentStage == 2 && score >= THIRD_STAGE_SCORE) currentStage = 3;
-            String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
-            file.writeString(stage, false);
+            String estagio = (String.valueOf(currentStage)+":"+String.valueOf(score));
+            file.writeString(estagio, false);
         }
     }
 
@@ -462,8 +462,8 @@ public class OverworldScreen extends BaseScreen {
             ), .7f, .8f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
             score += (18*lives)/3;
             if (currentStage == 3 && score >= FOURTH_STAGE_SCORE) currentStage = 4;
-            String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
-            file.writeString(stage, false);
+            String estagio = (String.valueOf(currentStage)+":"+String.valueOf(score));
+            file.writeString(estagio, false);
         }
     }
 
@@ -484,8 +484,8 @@ public class OverworldScreen extends BaseScreen {
             ), 0.9f, 1, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
             score += (36*lives)/3;
             if (currentStage == 4 && score >= LAST_STAGE_SCORE) currentStage = 5;
-            String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
-            file.writeString(stage, false);
+            String estagio = (String.valueOf(currentStage)+":"+String.valueOf(score));
+            file.writeString(estagio, false);
         }
     }
     
@@ -607,15 +607,15 @@ public class OverworldScreen extends BaseScreen {
         final float horizontalPosition = viewport.getWorldWidth() * 0.45f;
         final float verticalPosition = viewport.getWorldHeight();
         String text = String.valueOf(score) + "/" + getPontuacaoNecessaria();
-        messagesFont.setColor(Color.WHITE);
-        messagesFont.draw(batch,
+        fonteDeTexto.setColor(Color.WHITE);
+        fonteDeTexto.draw(batch,
                 "Pontos",
                 horizontalPosition,
                 verticalPosition * 0.95f,
                 0.9f * viewport.getWorldWidth(),
                 Align.center,
                 true);
-        messagesFont.draw(batch,
+        fonteDeTexto.draw(batch,
                 text,
                 horizontalPosition,
                 verticalPosition * 0.88f,

--- a/core/src/br/cefetmg/games/screens/OverworldScreen.java
+++ b/core/src/br/cefetmg/games/screens/OverworldScreen.java
@@ -19,12 +19,20 @@ import com.badlogic.gdx.assets.loaders.TextureLoader.TextureParameter;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.utils.Align;
 import java.util.ArrayList;
 import java.util.HashSet;
 
 public class OverworldScreen extends BaseScreen {
 
     private static final int NUMBER_OF_LEVELS = 5;
+    private static final int FIRST_STAGE_SCORE = 3;
+    private static final int SECOND_STAGE_SCORE = 9;
+    private static final int THIRD_STAGE_SCORE = 18;
+    private static final int FOURTH_STAGE_SCORE = 36;
+    private static final int LAST_STAGE_SCORE = 72;
     private Vector2 click;
     private Stage stage;
 
@@ -43,7 +51,7 @@ public class OverworldScreen extends BaseScreen {
             exit, menu, play, water;
     
     private final InputMultiplexer inputMultiplexer;
-    
+    private BitmapFont messagesFont;
     private ArrayList<Image> locks;
     private boolean desenhaMeio=true;
     private MyMusic backgroundMusic;
@@ -113,7 +121,7 @@ public class OverworldScreen extends BaseScreen {
         menu = new Image(assets.get("world/menu.png", Texture.class));
         play = new Image(assets.get("world/play.png", Texture.class));
         water = new Image(assets.get("world/water.jpg", Texture.class));
-
+        messagesFont = super.messagesFont;
         
         bool1 = true;
         desenhaMeio = true;
@@ -386,7 +394,7 @@ public class OverworldScreen extends BaseScreen {
                     )
             ), .1f, .2f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
             score += (3*lives)/3;
-            if (currentStage == 0 && score >= 3) currentStage = 1;
+            if (currentStage == 0 && score >= FIRST_STAGE_SCORE) currentStage = 1;
             String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
             file.writeString(stage, false);
         }
@@ -410,7 +418,7 @@ public class OverworldScreen extends BaseScreen {
                     )
             ), .3f, .4f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
             score += (6*lives)/3;
-            if (currentStage == 1 && score >= 9) currentStage = 2;
+            if (currentStage == 1 && score >= SECOND_STAGE_SCORE) currentStage = 2;
             String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
             file.writeString(stage, false);
         }
@@ -431,7 +439,7 @@ public class OverworldScreen extends BaseScreen {
                     )
             ), .5f, .6f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
             score += (9*lives)/3;
-            if (currentStage == 2 && score >= 18) currentStage = 3;
+            if (currentStage == 2 && score >= THIRD_STAGE_SCORE) currentStage = 3;
             String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
             file.writeString(stage, false);
         }
@@ -453,7 +461,7 @@ public class OverworldScreen extends BaseScreen {
                     )
             ), .7f, .8f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
             score += (18*lives)/3;
-            if (currentStage == 3 && score >= 36) currentStage = 4;
+            if (currentStage == 3 && score >= FOURTH_STAGE_SCORE) currentStage = 4;
             String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
             file.writeString(stage, false);
         }
@@ -475,7 +483,7 @@ public class OverworldScreen extends BaseScreen {
                     )
             ), 0.9f, 1, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
             score += (36*lives)/3;
-            if (currentStage == 4 && score >= 72) currentStage = 5;
+            if (currentStage == 4 && score >= LAST_STAGE_SCORE) currentStage = 5;
             String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
             file.writeString(stage, false);
         }
@@ -574,7 +582,40 @@ public class OverworldScreen extends BaseScreen {
 	batch.setProjectionMatrix(camera.combined);
         batch.begin();
             drawLocks();
+            drawScoreText();
         batch.end();
+    }
+    
+    public String getPontuacaoNecessaria() {
+        switch (currentStage){
+            case 0:
+                return String.valueOf(FIRST_STAGE_SCORE);
+            case 1:
+                return String.valueOf(SECOND_STAGE_SCORE);
+            case 2:
+                return String.valueOf(THIRD_STAGE_SCORE);
+            case 3:
+                return String.valueOf(FOURTH_STAGE_SCORE);
+            case 4:
+                return String.valueOf(LAST_STAGE_SCORE);
+                default:
+                    return String.valueOf(score);   
+        }
+    }
+    
+    public void drawScoreText () {
+        final float horizontalPosition = viewport.getWorldWidth() * 0.45f;
+        final float verticalPosition = viewport.getWorldHeight() * 0.95f;
+        String text = String.valueOf(score) + "/" + getPontuacaoNecessaria();
+        messagesFont.setColor(Color.WHITE);
+        messagesFont.draw(batch,
+                text,
+                horizontalPosition,
+                verticalPosition,
+                0.9f * viewport.getWorldWidth(),
+                Align.center,
+                true);
+        
     }
 
     @Override

--- a/core/src/br/cefetmg/games/screens/OverworldScreen.java
+++ b/core/src/br/cefetmg/games/screens/OverworldScreen.java
@@ -48,11 +48,13 @@ public class OverworldScreen extends BaseScreen {
     private boolean desenhaMeio=true;
     private MyMusic backgroundMusic;
     private int currentStage;
+    private int lives;
     private int score;
     FileHandle file;
 
-    public OverworldScreen(Game game, BaseScreen previous) {
+    public OverworldScreen(Game game, BaseScreen previous,int currentStage, int lives) {
         super(game, previous);
+        this.lives = lives;
         inputMultiplexer = new InputMultiplexer();
     }
 
@@ -245,7 +247,7 @@ public class OverworldScreen extends BaseScreen {
             file.writeString("0", true);
             currentStage = 0;
             score = 0;
-        }else {
+        }else if (currentStage == 0) {
             String arquivo = file.readString();
             String[] split = arquivo.split(":");
             currentStage = Integer.parseInt(split[0]);
@@ -382,9 +384,9 @@ public class OverworldScreen extends BaseScreen {
                             new BasCATballFactory(),
                             new RunningFactory()
                     )
-            ), .1f, .2f), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
-            score += 2;
-            if (currentStage == 0) currentStage = 1;
+            ), .1f, .2f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
+            score += (3*lives)/3;
+            if (currentStage == 0 && score >= 3) currentStage = 1;
             String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
             file.writeString(stage, false);
         }
@@ -406,9 +408,9 @@ public class OverworldScreen extends BaseScreen {
                             new DogBarksCatFleeFactory(),
                             new ClickFindCatFactory()
                     )
-            ), .3f, .4f), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
-            score += 4;
-            if (currentStage == 1) currentStage = 2;
+            ), .3f, .4f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
+            score += (6*lives)/3;
+            if (currentStage == 1 && score >= 9) currentStage = 2;
             String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
             file.writeString(stage, false);
         }
@@ -427,9 +429,9 @@ public class OverworldScreen extends BaseScreen {
                             new SpyFishFactory(),
                             new PhantomCatFactory()
                     )
-            ), .5f, .6f), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
-            score += 6;
-            if (currentStage == 2) currentStage = 3;
+            ), .5f, .6f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
+            score += (9*lives)/3;
+            if (currentStage == 2 && score >= 18) currentStage = 3;
             String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
             file.writeString(stage, false);
         }
@@ -449,9 +451,9 @@ public class OverworldScreen extends BaseScreen {
                             new HeadSoccerFactory(),
                             new CatAvoiderFactory()
                     )
-            ), .7f, .8f), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
-            score += 8;
-            if (currentStage == 3) currentStage = 4;
+            ), .7f, .8f, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
+            score += (18*lives)/3;
+            if (currentStage == 3 && score >= 36) currentStage = 4;
             String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
             file.writeString(stage, false);
         }
@@ -471,9 +473,9 @@ public class OverworldScreen extends BaseScreen {
                             //estevao e sarah//
                             new KillTheRatsFactory()
                     )
-            ), 0.9f, 1), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
-            score += 10;
-            if (currentStage == 4) currentStage = 5;
+            ), 0.9f, 1, currentStage), TransitionScreen.Effect.FADE_IN_OUT, 0.7f);
+            score += (36*lives)/3;
+            if (currentStage == 4 && score >= 72) currentStage = 5;
             String stage = (String.valueOf(currentStage)+":"+String.valueOf(score));
             file.writeString(stage, false);
         }

--- a/core/src/br/cefetmg/games/screens/OverworldScreen.java
+++ b/core/src/br/cefetmg/games/screens/OverworldScreen.java
@@ -605,13 +605,20 @@ public class OverworldScreen extends BaseScreen {
     
     public void drawScoreText () {
         final float horizontalPosition = viewport.getWorldWidth() * 0.45f;
-        final float verticalPosition = viewport.getWorldHeight() * 0.95f;
+        final float verticalPosition = viewport.getWorldHeight();
         String text = String.valueOf(score) + "/" + getPontuacaoNecessaria();
         messagesFont.setColor(Color.WHITE);
         messagesFont.draw(batch,
+                "Pontos",
+                horizontalPosition,
+                verticalPosition * 0.95f,
+                0.9f * viewport.getWorldWidth(),
+                Align.center,
+                true);
+        messagesFont.draw(batch,
                 text,
                 horizontalPosition,
-                verticalPosition,
+                verticalPosition * 0.88f,
                 0.9f * viewport.getWorldWidth(),
                 Align.center,
                 true);

--- a/core/src/br/cefetmg/games/screens/PlayingGamesScreen.java
+++ b/core/src/br/cefetmg/games/screens/PlayingGamesScreen.java
@@ -38,6 +38,7 @@ public class PlayingGamesScreen extends BaseScreen
     private final Hud hud;
     private PlayScreenState state;
     private int lives;
+    private int currentStage;
     private boolean hasPreloaded;
     private final InputMultiplexer inputMultiplexer;
     private MySound gameWonSound;
@@ -92,10 +93,11 @@ public class PlayingGamesScreen extends BaseScreen
     }
 
     public PlayingGamesScreen(Game game, BaseScreen previous, int nGames, Set<MiniGameFactory> games,
-            float initialDifficulty, float finalDifficulty) {
+            float initialDifficulty, float finalDifficulty, int currentStage) {
         super(game, previous);
         state = PlayScreenState.PLAYING;
         lives = Config.MAX_LIVES;
+        this.currentStage = currentStage;
         sequencer = new GameSequencer(nGames, games, initialDifficulty, finalDifficulty, this, this);
 
         hud = new Hud(this, this);
@@ -161,7 +163,7 @@ public class PlayingGamesScreen extends BaseScreen
 
                 } else if (sequencer instanceof GameSequencer) {
                     // volta para o menu principal
-                    transitionScreen(new OverworldScreen(super.game, this),
+                    transitionScreen(new OverworldScreen(super.game, this, currentStage, lives),
                             TransitionScreen.Effect.FADE_IN_OUT, 0.5f);
                 }
             }


### PR DESCRIPTION
@fegemo, fiz o ajuste que tava faltando do issue #60, ficando agora uma nova: uma nova fase será liberada se o jogador tiver terminado a ultima fase jogável e conseguir uma pontuação correta.
Sobre a pontuação que ele possui e precisa para a próxima fase, elas estão posicionadas no canto superior direito da tela do Overworld.